### PR TITLE
Revise heroku deployment doc.

### DIFF
--- a/source/docs/deploying/heroku/index.markdown
+++ b/source/docs/deploying/heroku/index.markdown
@@ -10,23 +10,44 @@ If you don't already have a Heroku account, [create one](https://api.heroku.com/
 
 ## Basic Octopress setup
 
-First make sure you've installed the Heroku gem
+First make sure you've installed the Heroku gem.
 
 ```sh
 gem install heroku
 ```
 
-Next create a heroku app for deployment. If this is your first time using Heroku, this command will ask for your account credentials,
-and automatically upload your public SSH key. If you don't already have a public key follow [Github's guide and create one](http://help.github.com/set-up-git-redirect/).
+Next create a heroku app for deployment. If this is your first time using the `heroku` gem, this command will ask for your account credentials.  If you don't already have a public key follow [Github's guide and create one](http://help.github.com/set-up-git-redirect/).  Then run the command:
+
+```sh
+heroku keys:add
+```
+
+to upload your public SSH key to Heroku.
+
+Now type:
 
 ```sh
 heroku create
 ```
 
-This will create a new Heroku app for you to deploy to and add a git remote named 'heroku'.
+This will create a new Heroku app for you to deploy to.
+
+The `heroku create` command will ask you for your credentials and print an output similar to the following:
+
+```
+Creating cool-name-9999... done, stack is cedar
+http://cool-name-9999.herokuapp.com/ | git@heroku.com:cool-name-9999.git
+```
+
+Take the URL for the git repository this command has given you and use it to add a remote to your local Octopress repository like so:
 
 ```sh
-# Set heroku to be the default remote for push/fetch
+git remote add heroku git@heroku.com:cool-name-9999.git
+```
+
+Run the following command to set heroku as the default remote for push and fetch operations:
+
+```sh
 git config branch.master.remote heroku
 ```
 


### PR DESCRIPTION
Now it is a bit clearer and covers adding the remote as well as
uploading your SSH key to heroku (which did not happen automatically for
me).
