### PR TITLE
CNAME file should be made in the public directory

### DIFF
--- a/source/docs/deploying/github/index.markdown
+++ b/source/docs/deploying/github/index.markdown
@@ -94,12 +94,12 @@ Now push your changes and you'll be all set.
 
 <h2 id="custom_domains">Custom Domains</h2>
 
-First you'll need to create a file named `CNAME` in your blog's source:
+First you'll need to create a file named `CNAME` in your blog's `public` directory:
 
 ``` sh
-echo 'your-domain.com' >> source/CNAME
+echo 'your-domain.com' >> public/CNAME
 # OR
-echo 'www.your-domain.com' >> source/CNAME
+echo 'www.your-domain.com' >> public/CNAME
 ```
 
 Next, you’ll need to visit your domain registrar or DNS host and add a record for your domain name.


### PR DESCRIPTION
## Background
According to GitHub docs, for a user pages repo, the `CNAME` file needs to live in the root dir of your repo on the `master` branch.

> **If you are working with a user pages repository, this should be done in the master branch.** If you're working with project pages, then it should go in the gh-pages branch of the project repository.

https://help.github.com/articles/setting-up-a-custom-domain-with-pages

## Problem
The current Octopress docs recommend placing the `CNAME` file in `source/`, but that doesn't achieve the above on deploy.

## Solution
The `CNAME` file needs to go into `public/` [so it will get copied to deploy/](https://github.com/imathis/octopress/blob/master/Rakefile#L261) and will live in the root dir of the repo on the `master` branch.