### PR TITLE
Updated the "Landing Page vs. Blog Index" how to to fix the empty blog post index

### DIFF
--- a/source/docs/theme/template/index.markdown
+++ b/source/docs/theme/template/index.markdown
@@ -30,6 +30,12 @@ Next you'll want to update your `Rakefile` to be sure your new blog index is pre
     blog_index_dir = 'source/blog'
 ```
 
+Then you may also need to update `_config.yml` to specify the pagination path in order to generate the blog index.
+
+``` ruby
+    paginate_path: "blog/posts/:num"
+```
+
 Remember to update the main navigation for your site, since currently the blog link points to `/`. Skip down to the section on [changing navigation](#changing_navigation), add a 'home' link and update the 'blog' link to point to `/blog/`.
 
 Finally, `source/index.html` can become the landing page of your wildest dreams.

--- a/source/docs/theme/template/index.markdown
+++ b/source/docs/theme/template/index.markdown
@@ -30,7 +30,7 @@ Next you'll want to update your `Rakefile` to be sure your new blog index is pre
     blog_index_dir = 'source/blog'
 ```
 
-Then you may also need to update `_config.yml` to specify the pagination path in order to generate the blog index.
+Then you may also need to update `_config.yml` to specify the pagination path in order to generate the list of blog posts on the index page.
 
 ``` ruby
     paginate_path: "blog/posts/:num"


### PR DESCRIPTION
When moving the blog index under source, the list of blog posts if not generated.

As discussed on [Google groups](https://groups.google.com/forum/#!topic/octopress/2jwtcmbJ1JA) here is the fix to get the list of blog post on the index page 