### PR TITLE
Add a link on generating the site faster

### DIFF
--- a/source/docs/blogging/index.markdown
+++ b/source/docs/blogging/index.markdown
@@ -125,3 +125,7 @@ cd -
 Now that you're setup with POW, you'll just run `rake watch` and load up `http://octopress.dev` instead.
 
 Also see [Sharing Code Snippets](/docs/blogging/code) and [Blogging with Plugins](/docs/blogging/plugins)
+
+## Faster site generation (Octopress 2)
+
+A way for faster site generation is explained in [this post](http://alvarogarcia7.github.io/blog/2015/07/13/faster-site-generation-for-octopress-2/)

--- a/source/docs/blogging/index.markdown
+++ b/source/docs/blogging/index.markdown
@@ -124,8 +124,8 @@ cd -
 
 Now that you're setup with POW, you'll just run `rake watch` and load up `http://octopress.dev` instead.
 
-Also see [Sharing Code Snippets](/docs/blogging/code) and [Blogging with Plugins](/docs/blogging/plugins)
-
 ## Faster site generation (Octopress 2)
 
 A way for faster site generation is explained in [this post](http://alvarogarcia7.github.io/blog/2015/07/13/faster-site-generation-for-octopress-2/)
+
+Also see [Sharing Code Snippets](/docs/blogging/code) and [Blogging with Plugins](/docs/blogging/plugins)


### PR DESCRIPTION
Feel free for copying the post entry from my site (source in https://github.com/alvarogarcia7/blog_source/blob/source/source/_posts/2015-07-13-faster-site-generation-for-octopress-2.markdown), as I didn't want to clutter the docs too much
